### PR TITLE
UnderscoreSerializer: Resource names basic pluralization/configuration

### DIFF
--- a/specs/emu/models.js.coffee
+++ b/specs/emu/models.js.coffee
@@ -1,12 +1,16 @@
 App.Address = Emu.Model.extend
-  town: Emu.field("string") 
+  town: Emu.field("string")
 
 App.Person = Emu.Model.extend
   name: Emu.field("string")
   address: Emu.field("App.Address")
 
+App.Person.reopenClass(resourceName: 'people')
+
 App.CustomPerson = App.Person.extend
   personId: Emu.field("string", {primaryKey: true})
+
+App.CustomPerson.reopenClass(resourceName: -> 'custom_people')
 
 App.Order = Emu.Model.extend
   orderCode: Emu.field("string")
@@ -15,7 +19,7 @@ App.Customer = Emu.Model.extend
   name: Emu.field("string")
   orders: Emu.field("App.Order", {collection: true, lazy: true})
   addresses: Emu.field("App.Address", {collection: true})
-  town: Emu.field("string", {partial: true})  
+  town: Emu.field("string", {partial: true})
 
 App.ClubTropicana = Emu.Model.extend
   drinksAreFree: Emu.field("string")

--- a/specs/emu/unit/serializer/underscore_serializer_specs.js.coffee
+++ b/specs/emu/unit/serializer/underscore_serializer_specs.js.coffee
@@ -1,66 +1,74 @@
 describe "Emu.UnderscoreSerializer", ->
-  
+
   describe "serializeKey", ->
-    
+
     describe "non caps first character", ->
       beforeEach ->
         @serializer = Emu.UnderscoreSerializer.create()
         @result = @serializer.serializeKey("daddyFellIntoThePond")
-      
+
       it "should have underscores as seperators", ->
         expect(@result).toEqual "daddy_fell_into_the_pond"
-    
+
     describe "caps first character", ->
       beforeEach ->
         @serializer = Emu.UnderscoreSerializer.create()
         @result = @serializer.serializeKey("DaddyFellIntoThePond")
-      
+
       it "should have underscores as seperators", ->
         expect(@result).toEqual "daddy_fell_into_the_pond"
-  
+
   describe "deserializeKey", ->
     beforeEach ->
       @serializer = Emu.UnderscoreSerializer.create()
       @result = @serializer.deserializeKey("daddy_fell_into_the_pond")
-    
+
     it "should have camel case", ->
       expect(@result).toEqual "daddyFellIntoThePond"
 
   describe "serializeTypeName", ->
-    beforeEach ->     
+    beforeEach ->
       @serializer = Emu.UnderscoreSerializer.create()
-      @result = @serializer.serializeTypeName(App.ClubTropicana)
-    
-    it "should serialize the name to underscore seperated", ->
-      expect(@result).toEqual("club_tropicana")
+
+    it "should serialize the name to underscore seperated and pluralized", ->
+      result = @serializer.serializeTypeName(App.ClubTropicana)
+      expect(result).toEqual("club_tropicanas")
+
+    it "should serialize the name using a user-defined name", ->
+      result = @serializer.serializeTypeName(App.Person)
+      expect(result).toEqual("people")
+
+    it "should serialize the name using a user-defined serialization rule if needed", ->
+      result = @serializer.serializeTypeName(App.CustomPerson)
+      expect(result).toEqual("custom_people")
 
   describe "serializeQueryHash", ->
     beforeEach ->
       serializer = Emu.UnderscoreSerializer.create()
       @result = serializer.serializeQueryHash(roastBeef: "yes", moreGravy: "dontmindifido", code: 10)
-    
+
     it "should serialize the query object to querystring parameters", ->
       expect(@result).toEqual("?roast_beef=yes&more_gravy=dontmindifido&code=10")
 
   describe "deserializeModel", ->
 
     describe "simple fields only", ->
-      beforeEach ->    
-        @jsonData = 
+      beforeEach ->
+        @jsonData =
           id: "46"
           drinks_are_free: "yes of course...I mean..why wouldn't they be?"
         @serializer = Emu.UnderscoreSerializer.create()
         @model = App.ClubTropicana.create()
         @serializer.deserializeModel(@model, @jsonData)
-      
+
       it "should always deserialize the id", ->
         expect(@model.get("id")).toEqual("46")
-      
+
       it "should set the deserialized value on the drinksAreFree field", ->
         expect(@model.get("drinksAreFree")).toEqual("yes of course...I mean..why wouldn't they be?")
 
   describe "serializeModel", ->
-    
+
     describe "simple fields", ->
       beforeEach ->
         model = App.ClubTropicana.create

--- a/src/emu/serializer/underscore_serializer.js.coffee
+++ b/src/emu/serializer/underscore_serializer.js.coffee
@@ -4,3 +4,13 @@ Emu.UnderscoreSerializer = Emu.Serializer.extend
 
   deserializeKey: (key) ->
     key.replace /(\_[a-z])/g, (x) -> x.toUpperCase().replace('_','')
+
+  serializeTypeName: (type) ->
+    if type.resourceName
+      name = type.resourceName
+      if typeof name is 'function' then name() else name
+    else
+      typeString = type.toString()
+      parts = typeString.split '.'
+      name = parts[parts.length - 1]
+      name.replace(/([A-Z])/g, '_$1').toLowerCase().slice(1) + 's'


### PR DESCRIPTION
By default all models will have their name underscored and pluralized by simply adding a 's' at the end. If someone ever want something else, it’s configurable by reopening the model’s class:

``` javascript
App.MyModel.reopenClass({
  resourceName: 'my_special_models'
});
```

or

``` javascript
App.MyModel.reopenClass({
  resourceName: function() {
    return 'my_special_models';
  }
});
```
