### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/breaking_changes.md
+++ b/breaking_changes.md
@@ -1,4 +1,4 @@
-#Breaking Changes
+# Breaking Changes
 
 Revision 1
 ----------

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Emu [![Build Status](https://secure.travis-ci.org/charlieridley/emu.png?branch=master)](https://travis-ci.org/charlieridley/emu)
+# Emu [![Build Status](https://secure.travis-ci.org/charlieridley/emu.png?branch=master)](https://travis-ci.org/charlieridley/emu)
 
 Emu is a simple data access library for [Ember.js](http://www.emberjs.com).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
